### PR TITLE
Add explicit on /off as per advanced mode working observed

### DIFF
--- a/smappy/smappy.py
+++ b/smappy/smappy.py
@@ -671,19 +671,6 @@ class LocalSmappee(object):
         """
         return self._basic_post(url='commandControlPublic', data='controlGroup')
 
-    def on_off_command_control(self, val_id):
-        """
-        Parameters
-        ----------
-        val_id : str
-
-        Returns
-        -------
-        requests.Response
-        """
-        data = "control,controlId=" + val_id
-        return self._basic_post(url='commandControlPublic', data=data)
-
     def on_command_control(self, val_id):
         """
         Parameters

--- a/smappy/smappy.py
+++ b/smappy/smappy.py
@@ -684,6 +684,32 @@ class LocalSmappee(object):
         data = "control,controlId=" + val_id
         return self._basic_post(url='commandControlPublic', data=data)
 
+    def on_command_control(self, val_id):
+        """
+        Parameters
+        ----------
+        val_id : str
+
+        Returns
+        -------
+        requests.Response
+        """
+        data = "control,controlId=1|" + val_id
+        return self._basic_post(url='commandControlPublic', data=data)
+
+    def off_command_control(self, val_id):
+        """
+        Parameters
+        ----------
+        val_id : str
+
+        Returns
+        -------
+        requests.Response
+        """
+        data = "control,controlId=0|" + val_id
+        return self._basic_post(url='commandControlPublic', data=data)
+
     def add_command_control(self, *args, **kwargs):
         """
         Parameters


### PR DESCRIPTION
Add explicit on /off as per advanced mode working observed
Removed `on_off_command_control` because it was not working
 
Sample stacktrace:
```
Traceback (most recent call last):
  File "/master/development/home-assistant/homeassistant/core.py", line 1032, in _event_to_service_call
    yield from service_handler.func(service_call)
  File "/master/development/home-assistant/homeassistant/components/switch/__init__.py", line 113, in async_handle_switch_service
    yield from switch.async_turn_on()
  File "/usr/local/Cellar/python3/3.6.4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/asyncio/futures.py", line 327, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/local/Cellar/python3/3.6.4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/asyncio/tasks.py", line 250, in _wakeup
    future.result()
  File "/usr/local/Cellar/python3/3.6.4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/asyncio/futures.py", line 243, in result
    raise self._exception
  File "/usr/local/Cellar/python3/3.6.4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/master/development/home-assistant/homeassistant/components/switch/smappee.py", line 74, in turn_on
    self._smappee.actuator_on(self._location_id, self._switch_id)
  File "/master/development/home-assistant/homeassistant/components/smappee.py", line 187, in actuator_on
    self._localsmappy.on_off_command_control(actuator_id)
  File "/master/development/home-assistant/lib/python3.6/site-packages/smappy/smappy.py", line 685, in on_off_command_control
    return self._basic_post(url='commandControlPublic', data=data)
  File "/master/development/home-assistant/lib/python3.6/site-packages/smappy/smappy.py", line 508, in _basic_post
    r.raise_for_status()
  File "/master/development/home-assistant/lib/python3.6/site-packages/requests/models.py", line 935, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: http://192.168.0.10/gateway/apipublic/commandControlPublic
```
  