### PR TITLE
Using smappee APIv2 instead of APIv1

### DIFF
--- a/smappy/smappy.py
+++ b/smappy/smappy.py
@@ -10,8 +10,8 @@ __author__ = "EnergieID.be"
 __license__ = "MIT"
 
 URLS = {
-    'token': 'https://app1pub.smappee.net/dev/v1/oauth2/token',
-    'servicelocation': 'https://app1pub.smappee.net/dev/v1/servicelocation'
+    'token': 'https://app1pub.smappee.net/dev/v2/oauth2/token',
+    'servicelocation': 'https://app1pub.smappee.net/dev/v2/servicelocation'
 }
 
 


### PR DESCRIPTION
Smappee just release v2 of their API https://smappee.atlassian.net/wiki/spaces/DEVAPI/pages/526581817/Get+Sensor+Consumption#GetSensorConsumption-Version2(v2)

by using this version of the API the temperature unit is returned as degrees Celsius instead of centi degrees Celsius which is more human readable which resolves #30 